### PR TITLE
[BIZ-6315] Updates template to include our typical boilerplate

### DIFF
--- a/lib/generators/templates/data_migration_generator.rb
+++ b/lib/generators/templates/data_migration_generator.rb
@@ -7,6 +7,10 @@ class ClassName < ActiveRecord::DataMigration
 
   sig { void }
   def up
+    Rails.logger.info('starting TODO-message')
+
     # put your code to modify data and output results here
+
+    Rails.logger.info('finished TODO-message')
   end
 end

--- a/lib/generators/templates/data_migration_generator.rb
+++ b/lib/generators/templates/data_migration_generator.rb
@@ -1,5 +1,12 @@
+# typed: strict
+
 class ClassName < ActiveRecord::DataMigration
+  extend T::Sig
+
+  disable_ddl_transaction!
+
+  sig { void }
   def up
-    # put your code here
+    # put your code to modify data and output results here
   end
 end

--- a/lib/rails_data_migrations/version.rb
+++ b/lib/rails_data_migrations/version.rb
@@ -1,3 +1,3 @@
 module RailsDataMigrations
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.0.1'.freeze
 end

--- a/lib/rails_data_migrations/version.rb
+++ b/lib/rails_data_migrations/version.rb
@@ -1,3 +1,3 @@
 module RailsDataMigrations
-  VERSION = '1.2.0.1'.freeze
+  VERSION = '1.2.1'.freeze
 end


### PR DESCRIPTION
Small change to modify the generator's template to our typical boilerplate for data migrations. 

Initially looked at modifying in our backend, but testing overriding the template there did not use the new template and I saw that we already had a fork, so just swapped over to modifying here.

Tested a new data migration created from this template for both rubocop and sorbet errors.
```
rails g long_running_migration modify_biz_basic_title_orgs
      create  db/long_running_migrations/20240711224548_modify_biz_basic_title_orgs.rb

# bundle exec rubocop db/long_running_migrations/20240711224548_modify_biz_basic_title_orgs.rb
Inspecting 1 file
.
1 file inspected, no offenses detected

# srb tc
No errors! Great job.
```
